### PR TITLE
flask run タイミング制御

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
     depends_on:
       - db
     tty: true
-    command: flask run --host 0.0.0.0 --port 5000
+    #command: flask run --host 0.0.0.0 --port 5000
+    command: sh -c "while ! mysqladmin ping -h db -u root -proot --silent; do sleep 3; done && echo 'mysql running!!!' && flask run --host 0.0.0.0 --port 5000"
 
   db:
     build: ./db

--- a/flaskproject/Dockerfile
+++ b/flaskproject/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3
 ENV PYTHONUNBUFFERED 1
+RUN apt-get update
+RUN apt-get -y install mariadb-client
 RUN mkdir /app
 WORKDIR /app
 COPY requirements.txt /app/


### PR DESCRIPTION
dbのコンテナより先にflaskのコンテナが立ち上がってしまうと、db接続エラーが発生しflaskコンテナが落ちる現象が発生したため、mysqlが立ち上がるのを待ってからflask run するように修正しました。